### PR TITLE
ci: fix deploy.yml

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -31,4 +31,4 @@ jobs:
 
           \            "
       - name: Deploy EcsDeployPipeline Stack
-        run: npx cdk deploy --require-approval never --outputs-file cdk-outputs-ecs-deploy.json aws-cobol-cicd-example-dev-ecs-pipeline
+        run: npx cdk deploy --require-approval never --outputs-file cdk-outputs-ecs-deploy.json --all

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,5 +30,5 @@ jobs:
           \              echo CDK_DEFAULT_ACCOUNT=\"${{ secrets.AWS_ID }}\" >> \"$GITHUB_ENV\"
 
           \            "
-      - name: Deploy EcsDeployPipeline Stack
+      - name: Deploy a stack
         run: npx cdk deploy --require-approval never --outputs-file cdk-outputs-ecs-deploy.json --all

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -273,7 +273,7 @@ new YamlFile(project, '.github/workflows/deploy.yml', {
             `,
           },
           {
-            name: 'Deploy EcsDeployPipeline Stack',
+            name: 'Deploy a stack',
             run: 'npx cdk deploy --require-approval never --outputs-file cdk-outputs-ecs-deploy.json --all',
           },
         ],

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -274,7 +274,7 @@ new YamlFile(project, '.github/workflows/deploy.yml', {
           },
           {
             name: 'Deploy EcsDeployPipeline Stack',
-            run: 'npx cdk deploy --require-approval never --outputs-file cdk-outputs-ecs-deploy.json aws-cobol-cicd-example-dev-ecs-pipeline',
+            run: 'npx cdk deploy --require-approval never --outputs-file cdk-outputs-ecs-deploy.json --all',
           },
         ],
       },


### PR DESCRIPTION
This pull request includes changes to the deployment process by modifying the deployment command to deploy all stacks instead of a specific stack.

Deployment process changes:

* [`.github/workflows/deploy.yml`](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L34-R34): Updated the deployment command to use the `--all` flag, which deploys all stacks instead of just the `aws-cobol-cicd-example-dev-ecs-pipeline` stack.
* [`.projenrc.ts`](diffhunk://#diff-bda22a3de7550efc76dd29e2a427a8d5abd5863f6e96a339ff47390d9bed7d14L277-R277): Modified the deployment command to use the `--all` flag for deploying all stacks.